### PR TITLE
method checking proxies + alter exception type

### DIFF
--- a/lib/celluloid/method.rb
+++ b/lib/celluloid/method.rb
@@ -2,7 +2,7 @@ module Celluloid
   # Method handles that route through an actor proxy
   class Method
     def initialize(proxy, name)
-      raise NameError, "undefined method `#{name}'" unless proxy.respond_to? name
+      raise NoMethodError, "undefined method `#{name}'" unless proxy.respond_to? name
 
       @proxy, @name = proxy, name
       @klass = @proxy.class


### PR DESCRIPTION
Just 2 examples for custom proxies - and how to protect from errors on the "client" side.

I added them as specs - mostly so they are covered by tests (as opposed to examples in the examples dir).

Reasoning: for some people, method+arity checking may not be enough (e.g. they'd want something like strong parameters in Rails). For others, they shouldn't pay for the overhead of invoking extra methods - without a way of opting out.