### PR TITLE
Avoid installing unused rspec-log_split on Travis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'benchmark_suite'
   gem 'rspec', '~> 3.2'
   gem 'rspec-retry'
-  gem 'rspec-log_split', github: 'abstractive/rspec-log_split', branch: 'master'
 end
 
 group :gem_build_tools do


### PR DESCRIPTION
Not used (see .env-ci - defaults to stderr)